### PR TITLE
Fix #1

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
 	"dependencies": {
 		"@ktibow/iconset-material-symbols": "^0.0.1752989765",
 		"@ktibow/material-color-utilities-nightly": "^0.3.11753407547043",
-		"dreamland": "link:../dreamland"
+		"dreamland": "^0.1.2"
 	}
 }


### PR DESCRIPTION
Replaces `link:../dreamland` with `^0.1.2` in `package.json`